### PR TITLE
Add evals using pydantic evals

### DIFF
--- a/evals.py
+++ b/evals.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+from pydantic_evals import Dataset
+from pydantic_evals.evaluators import Evaluator, EvaluatorContext, IsInstance
+
+from invitations_manager import InvitationDecision, agent
+
+# Define test cases for the LinkedIn invitation agent
+
+
+class CorrectDecisionEvaluator(Evaluator[str, InvitationDecision]):
+    def evaluate(self, ctx: EvaluatorContext[str, InvitationDecision]) -> float:
+        if ctx.expected_output and ctx.output.action == ctx.expected_output.action:
+            return 1.0
+        else:
+            return 0.0
+
+
+# Load cases from YAML file
+dataset = Dataset[str, InvitationDecision, dict].from_file(Path("linkedin_invitation_cases.yaml"))
+dataset.evaluators = [IsInstance(type_name="InvitationDecision"), CorrectDecisionEvaluator()]
+
+
+async def agent_decision(input_str: str) -> InvitationDecision:
+    result = await agent.run(input_str)
+    return result.output
+
+
+def main():
+    report = dataset.evaluate_sync(agent_decision)
+    report.print(include_input=True, include_output=True, include_durations=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/linkedin_invitation_cases.yaml
+++ b/linkedin_invitation_cases.yaml
@@ -1,0 +1,103 @@
+cases:
+- name: Amina Diallo
+  inputs: 'Name: Amina Diallo, Job Title: Cloud Solution Architect | AI , Profile Link:
+    https://www.linkedin.com/in/amina-diallo-1234africa/, Connection Info: True.'
+  expected_output:
+    action: accept
+    reason: Amina Diallo has a technical role as a Cloud Solution Architect and also
+      has mutual connections.
+  metadata: {}
+- name: Lucas Kim
+  inputs: 'Name: Lucas Kim, Job Title: Senior Solution Delivery Engineer @ GitHub
+    | Facilitating development and implementation of enterprise DevSecOps strategy,
+    Profile Link: https://www.linkedin.com/in/lucas-kim-sea/, Connection Info: True.'
+  expected_output:
+    action: accept
+    reason: The individual holds a technical role as a Senior Solution Delivery Engineer
+      at GitHub and there are mutual connections.
+  metadata: {}
+- name: Priya Nair
+  inputs: 'Name: Priya Nair, Job Title: Staff Data Scientist - Applied ML at Broadcom,
+    Profile Link: https://www.linkedin.com/in/priya-nair-india/, Connection Info: True.'
+  expected_output:
+    action: accept
+    reason: Priya Nair has a technical role as a Staff Data Scientist and is a mutual
+      connection.
+  metadata: {}
+- name: Diego Alvarez
+  inputs: 'Name: Diego Alvarez, Job Title: Software | AI | Full-stack Engineer
+    | Mentor, Profile Link: https://www.linkedin.com/in/diego-alvarez-mexico/, Connection
+    Info: True.'
+  expected_output:
+    action: accept
+    reason: The person has a technical role as a Software/AI/Full-stack Engineer and
+      there are mutual connections.
+  metadata: {}
+- name: Sofia Rossi
+  inputs: 'Name: Sofia Rossi, Job Title: Founders Mode @Stealth | Machine Learning
+    Consultant | TWiML | Cohere Labs Community Lead & Researcher | Lucknow AI Labs,
+    Profile Link: https://www.linkedin.com/in/sofia-rossi-europe/, Connection Info: True.'
+  expected_output:
+    action: accept
+    reason: The person has a technical role in machine learning and AI, and there
+      is a mutual connection.
+  metadata: {}
+- name: Ethan Smith
+  inputs: 'Name: Ethan Smith, Job Title: Future of Work Architect | AI Adoption &
+    Digital Transformation Specialist | Top 50 Remote Innovator | Top 100 Future of
+    Work Leader, Profile Link: https://www.linkedin.com/in/ethan-smith-uk/, Connection
+    Info: True.'
+  expected_output:
+    action: undecided
+    reason: The profile does not explicitly mention a technical role, mutual connections
+      are not specified, and there's no mention of working at Microsoft.
+  metadata: {}
+- name: Ethan Smith (Full Profile)
+  inputs: "Full profile information for Ethan Smith (Future of Work Architect | AI\
+    \ Adoption & Digital Transformation Specialist | Top 50 Remote Innovator | Top\
+    \ 100 Future of Work Leader):\nEthan Smith\n  \n2nd degree connection\n2nd\
+    \nFuture of Work Architect | AI Adoption & Digital Transformation Specialist |\
+    Top 50 Remote Innovator | Top 100 Future of Work Leader\nGlasgow, Scotland, United\
+    Kingdom  Contact info\n\nBased on this additional information, should we accept\
+    \ or ignore this invitation? Provide a reason for your decision."
+  expected_output:
+    action: undecided
+    reason: The profile does not clearly indicate a technical role or affiliation
+      with Microsoft, nor is there mention of mutual connections. However, the title
+      suggests possible technical involvement in AI and digital transformation, making
+      it unclear if the acceptance criteria are met.
+  metadata: {}
+- name: Lila Zhang
+  inputs: 'Name: Lila Zhang, Job Title: LSE Law, Profile Link: https://www.linkedin.com/in/lila-zhang-law/, Connection Info: True.'
+  expected_output:
+    action: accept
+    reason: The invitation is accepted due to having mutual connections.
+  metadata: {}
+- name: Daniel Müller
+  inputs: 'Name: Daniel Müller, Job Title: Microsoft Azure Consultant / Architect;
+    Ex-Microsoft, Profile Link: https://www.linkedin.com/in/daniel-muller-germany/, Connection
+    Info: True.'
+  expected_output:
+    action: accept
+    reason: The person has a technical role as a Microsoft Azure Consultant / Architect
+      and has worked at Microsoft.
+  metadata: {}
+- name: Fatima El Amrani
+  inputs: 'Name: Fatima El Amrani, Job Title: Applying NLP, LLMs, Agents, Graph ML | SAP |
+    ISB | MLOPS | AI/ML | DevOps | Automation, Profile Link: https://www.linkedin.com/in/fatima-elamrani-morocco/, Connection Info: True.'
+  expected_output:
+    action: accept
+    reason: The person has a technical role and there is a mutual connection.
+  metadata: {}
+- name: Dr. Samuel Okoro
+  inputs: 'Name: Dr. Samuel Okoro, Job Title: Experienced Medical Educator @ MAcadMEd | Mentor @ ESGE & BSG | Experienced Endosonographer (i-EUS, EUSRA, TREUS, IBUS) | Endo-Pangreatobiliary Endoscopist | 3rd Space Endoscopist | Neurogastroenterologist | AI Scholar, Profile Link: https://www.linkedin.com/in/samuel-okoro-nigeria/, Connection Info: False.'
+  expected_output:
+    action: undecided
+    reason: The profile describes a medical educator and specialist in endoscopy and AI scholarship, which are not explicitly technical roles related to technology or Microsoft. No mutual connections or Microsoft affiliation is mentioned.
+  metadata: {}
+- name: Dr. Samuel Okoro (Full Profile)
+  inputs: "Full profile information for Dr. Samuel Okoro (Experienced Medical Educator @ MAcadMEd | Mentor @ ESGE & BSG | Experienced Endosonographer (i-EUS, EUSRA, TREUS, IBUS) | Endo-Pangreatobiliary Endoscopist | 3rd Space Endoscopist | Neurogastroenterologist | AI Scholar):\nDr. Samuel Okoro\n He/Him  \n3rd degree connection\n3rd\nExperienced Medical Educator @ MAcadMEd | Mentor @ ESGE & BSG | Experienced Endosonographer (i-EUS, EUSRA, TREUS, IBUS) | Endo-Pangreatobiliary Endoscopist | 3rd Space Endoscopist | Neurogastroenterologist | AI Scholar\nLagos, Nigeria  Contact info\n\nBased on this additional information, should we accept or ignore this invitation? Provide a reason for your decision."
+  expected_output:
+    action: ignore
+    reason: The individual is a medical educator and endoscopist, which are not technical roles as defined for acceptance criteria, and there are no mentions of mutual connections or employment at Microsoft.
+  metadata: {}

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ dotenv-azd
 aiohttp
 playwright
 pydantic-ai
+pydantic-evals


### PR DESCRIPTION
This pull request introduces functionality for evaluating and logging decisions made by an agent processing LinkedIn invitations. The changes include adding a test evaluation framework, enabling the recording of evaluation cases, and providing a sample dataset of test cases. Below is a summary of the most important changes grouped by theme:

### Evaluation Framework and Test Cases
* Added a new `CorrectDecisionEvaluator` class in `evals.py` to evaluate the agent's decisions against expected outputs using a scoring mechanism. The evaluator is integrated with a dataset loaded from a YAML file (`linkedin_invitation_cases.yaml`).
* Introduced a sample dataset of LinkedIn invitation test cases in `linkedin_invitation_cases.yaml`, including inputs, expected outputs, and metadata for evaluation purposes.

### Functionality for Logging and Recording Evaluation Cases
* Added the `run_and_log_agent` function in `invitations_manager.py` to run the agent, log its input/output as YAML evaluation cases, and return the decision. This function ensures cases are appended to the dataset file.
* Updated the `process_linkedin_invitations` function in `invitations_manager.py` to include a `record_eval_cases` flag. When enabled, the function uses `run_and_log_agent` to log decisions instead of directly running the agent. [[1]](diffhunk://#diff-effdeb6d7883496a76c9d6b6deac23ea4527c319728c27acfce2d1f9b950ad0fL131-R165) [[2]](diffhunk://#diff-effdeb6d7883496a76c9d6b6deac23ea4527c319728c27acfce2d1f9b950ad0fR225-R228) [[3]](diffhunk://#diff-effdeb6d7883496a76c9d6b6deac23ea4527c319728c27acfce2d1f9b950ad0fR241-R247)

### Command-Line Interface Enhancements
* Enhanced the CLI in `invitations_manager.py` to include a `--record-eval-cases` flag, allowing users to enable the recording of evaluation cases when processing LinkedIn invitations.